### PR TITLE
Add support for subcommand section headings

### DIFF
--- a/sample-complex/main.go
+++ b/sample-complex/main.go
@@ -20,9 +20,11 @@ var application = &subcommands.DefaultApplication{
 	// Commands will be shown in this exact order, so you'll likely want to put
 	// them in alphabetical order or in logical grouping.
 	Commands: []*subcommands.Command{
+		subcommands.Section("Nonsleepy commands."),
 		cmdGreet,
 		subcommands.CmdHelp,
 		cmdAsk,
+		subcommands.Section("Sleepy commands."),
 		cmdSleep,
 	},
 	EnvVars: map[string]subcommands.EnvVarDefinition{

--- a/subcommands.go
+++ b/subcommands.go
@@ -138,6 +138,8 @@ type Command struct {
 	LongDesc   string
 	Advanced   bool
 	CommandRun func() CommandRun
+
+	isSection bool
 }
 
 // Name returns the command's name: the first word in the usage line.
@@ -148,6 +150,15 @@ func (c *Command) Name() string {
 		name = name[:i]
 	}
 	return name
+}
+
+// Section returns an un-runnable command that can act as a nice section
+// heading for other commands.
+func Section(name string) *Command {
+	return &Command{
+		ShortDesc: "\n\t" + name,
+		isSection: true,
+	}
 }
 
 // usage prints out the general application usage.
@@ -258,7 +269,9 @@ func FindCommand(a Application, name string) *Command {
 func FindNearestCommand(a Application, name string) *Command {
 	commands := map[string]*Command{}
 	for _, c := range a.GetCommands() {
-		commands[c.Name()] = c
+		if !c.isSection {
+			commands[c.Name()] = c
+		}
 	}
 	if c, ok := commands[name]; ok {
 		return c


### PR DESCRIPTION
Section headings are dummy "Commands" that have a private flag on them
which prevents them from being run.