### PR TITLE
Allow GetFlags to return nil.

### DIFF
--- a/sample-complex/ask.go
+++ b/sample-complex/ask.go
@@ -18,6 +18,7 @@ var askApplication = &subcommands.DefaultApplication{
 	Commands: []*subcommands.Command{
 		cmdAskApple,
 		cmdAskBeer,
+		cmdAskArbitrary,
 		cmdHelp,
 	},
 }

--- a/sample-complex/ask_arbitrary.go
+++ b/sample-complex/ask_arbitrary.go
@@ -1,0 +1,43 @@
+// Copyright 2014 Marc-Antoine Ruel. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/maruel/subcommands"
+)
+
+var cmdAskArbitrary = &subcommands.Command{
+	UsageLine: "arbitrary <anything>",
+	ShortDesc: "asks for anything you want",
+	LongDesc:  "Asks for arbitrary arguments.",
+	CommandRun: func() subcommands.CommandRun {
+		// note that askArbitraryRun has no Flags
+		return &askArbitraryRun{}
+	},
+}
+
+type askArbitraryRun struct {
+}
+
+func (c *askArbitraryRun) GetFlags() *flag.FlagSet { return nil }
+
+func (c *askArbitraryRun) Run(a subcommands.Application, args []string, env subcommands.Env) int {
+	if len(args) == 0 {
+		fmt.Fprintf(a.GetErr(), "%s: expected a question.", a.GetName())
+		return 1
+	}
+	if last := args[len(args)-1]; !strings.HasSuffix(last, "?") {
+		fmt.Fprintf(a.GetErr(), "%s: expected a question ending with `?`.", a.GetName())
+		return 1
+	}
+
+	fmt.Println("You asked:", strings.Join(args, " "))
+	fmt.Println("That's a great question!")
+	return 0
+}

--- a/sample-complex/main_test.go
+++ b/sample-complex/main_test.go
@@ -110,8 +110,9 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
@@ -127,8 +128,9 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
@@ -144,8 +146,9 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
@@ -160,9 +163,10 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  beer   asks for beer\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  beer       asks for beer\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
@@ -176,8 +180,9 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
@@ -192,13 +197,19 @@ func TestHelp(t *testing.T) {
 				"Usage:  sample-complex ask [command] [arguments]\n" +
 				"\n" +
 				"Commands:\n" +
-				"  apple  asks for an apple\n" +
-				"  beer   asks for beer\n" +
-				"  help   prints help about a command\n" +
+				"  apple      asks for an apple\n" +
+				"  beer       asks for beer\n" +
+				"  arbitrary  asks for anything you want\n" +
+				"  help       prints help about a command\n" +
 				"\n" +
 				"\n" +
 				"Use \"sample-complex ask help [command]\" for more information about a command.\n" +
 				"\n",
+			0,
+		},
+		{
+			[]string{"ask", "arbitrary", "-flags", "-don't", "matter?"},
+			"You asked: -flags -don't matter?\nThat's a great question!\n",
 			0,
 		},
 	}


### PR DESCRIPTION
This allows individual subcommands to indicate that they would like to
take full control of the 'args' parsing. This is useful for when 'flag'
is insufficiently groovy, or when writing wrapper programs where some
or even none of the flags need to be interpreted by the wrapper itself
(e.g. merely passed through to the target program).

Without this, invocations such as `prog subcommand -flag` will fail
because `-flag` would be interpreted as an 'unknown flag'.